### PR TITLE
Forced apt to only install necessary packages (for 20.10)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ add-apt-repository ppa:team-xbmc/ppa -y
 apt update -y && apt upgrade -y
 
 # install kodi and screen output
-apt install kodi xinit xorg dbus-x11 xserver-xorg-video-intel xserver-xorg-legacy pulseaudio upower -y
+apt install kodi xinit xorg dbus-x11 xserver-xorg-video-intel xserver-xorg-legacy pulseaudio upower -y --no-install-recommends --no-install-suggests
 
 # add user
 adduser --disabled-password --disabled-login --gecos "" kodi


### PR DESCRIPTION
Without this modification, apt would install gnome-shell and boot into that.